### PR TITLE
fix #5 only : checkboxes for type multi are deselected when query is parsed

### DIFF
--- a/src/services/QueryService.js
+++ b/src/services/QueryService.js
@@ -72,7 +72,7 @@
           var vals = group[key][obj.field];
           if (typeof vals === 'string') vals = [ vals ];
           obj.values = fieldData.choices.reduce(function(prev, choice) {
-            prev[choice] = truthy === (~group[key][obj.field].indexOf(choice));
+            prev[choice] = (group[key][obj.field].indexOf(choice) != -1);
             return prev;
           }, {});
         } else {


### PR DESCRIPTION
Hi @dncrews ,

As discussed this is a fix for issue #5 ONLY which appeared with commit e79a94b

I have suggested a fix without using the truthy logic in the commit.

With the truthy logic, a double bang is needed before tilde:
prev[choice] = (truthy === (!!~group[key][obj.field].indexOf(choice)));
